### PR TITLE
Do not use mkdir -v option

### DIFF
--- a/mime-types/add_csound_mimetypes.sh
+++ b/mime-types/add_csound_mimetypes.sh
@@ -6,7 +6,7 @@ if [ -z "$SHAREDIR" ] ; then
 	SHAREDIR=/usr/share #~/.local/share # use the latter one for local install
 fi
 ICONDIR=$SHAREDIR/icons/hicolor/128x128/mimetypes
-mkdir -v -p $ICONDIR
+mkdir -p $ICONDIR
 # cp -v csound-light-128.png $ICONDIR/csound.png
 # cp -v csound-dark-128.png $ICONDIR/csound.png
 cp -v csound.png $ICONDIR/csound.png
@@ -16,7 +16,7 @@ cp -v csound.png $ICONDIR/csound.png
 #create and register mimetype
 MIMEDIR=$SHAREDIR/mime # or /usr/share/mime
 DESTDIR=$MIMEDIR/packages
-mkdir -v -p $DESTDIR # make if does not exist
+mkdir -p $DESTDIR # make if does not exist
 cp -v *.xml $DESTDIR
 # Only update db if it already exists
 # packages will install into empty trees and


### PR DESCRIPTION
The option `-v` of `mkdir` is not standard, see https://pubs.opengroup.org/onlinepubs/9799919799/utilities/mkdir.html.
For example, this option is not available on _OpenBSD_ and _NetBSD_.