### PR TITLE
Omit target.files in qcs.pro

### DIFF
--- a/qcs.pro
+++ b/qcs.pro
@@ -146,7 +146,6 @@ unix:!macx {
 	}
 
 	target.path = $$INSTALL_DIR/bin
-	target.files = $$OUT_PWD/$$DESTDIR/$$TARGET # do not install with the full name
 	INSTALLS += target
 
 	postInstall.path = $$INSTALL_DIR/bin


### PR DESCRIPTION
Accoding to the qmake documentation, `target.files` is not needed (see https://doc.qt.io/qt-6/qmake-advanced-usage.html#installing-files). 
I don't know why, but this fixes a problem for me on OpenBSD where `make install` sometimes did not install the binary correctly.