### PR TITLE
Add defines for default executables on OpenBSD

### DIFF
--- a/src/csoundqt.cpp
+++ b/src/csoundqt.cpp
@@ -2896,7 +2896,7 @@ void CsoundQt::openManualExample(QString fileName)
 void CsoundQt::openExternalBrowser(QUrl url)
 {
     QString test = url.toString();
-    if (!m_options->browser.isEmpty() && QFile::exists(m_options->browser)) {
+    if (!m_options->browser.isEmpty()) {
         //execute(m_options->browser, "\"" + url.toString() + "\"");
         startProcess(m_options->browser, QStringList(url.toString()));
         // execute(m_options->browser, url.toString()); // remove quotes, otherwise wrong with changed QProcess

--- a/src/types.h
+++ b/src/types.h
@@ -97,6 +97,17 @@
 #define DEFAULT_DOT_EXECUTABLE "dot"
 #define DEFAULT_LOG_FILE ""
 #endif
+#ifdef Q_OS_OPENBSD
+#define DEFAULT_HTML_DIR "/usr/local/share/doc/csound-doc/html"
+#define DEFAULT_TERM_EXECUTABLE "xterm"
+#define DEFAULT_BROWSER_EXECUTABLE "firefox"
+#define DEFAULT_WAVEEDITOR_EXECUTABLE "audacity"
+#define DEFAULT_WAVEPLAYER_EXECUTABLE "paplay"
+#define DEFAULT_PDFVIEWER_EXECUTABLE ""
+#define DEFAULT_DOT_EXECUTABLE "dot"
+#define DEFAULT_LOG_FILE ""
+#define DEFAULT_SCRIPT_DIR "/usr/local/share/csoundqt/Scripts"
+#endif
 
 #define CSQT_DEFAULT_TEMPLATE "<CsoundSynthesizer>\n<CsOptions>\n-odac\n</CsOptions>\n<CsInstruments>\n\nsr = 44100\nksmps = 64\nnchnls = 2\n0dbfs = 1\n\n\n</CsInstruments>\n<CsScore>\n\n</CsScore>\n</CsoundSynthesizer>"
 


### PR DESCRIPTION
This also removes a check for file existence in `openExternalBrowser()`. This way, it is not necessary to configure the entire path to the executable. (There is no such check for the other executables either.)