### PR TITLE
Find templatePath regardless of the operating system

### DIFF
--- a/src/csoundqt.cpp
+++ b/src/csoundqt.cpp
@@ -5064,38 +5064,26 @@ void CsoundQt::fillFileMenu()
     templateMenu->clear();
     QString templatePath = m_options->templateDir;
     if (templatePath.isEmpty() || !QDir(templatePath).exists()) {
-#ifdef Q_OS_WIN32
-        templatePath = qApp->applicationDirPath() + "/templates/";
-#endif
-#ifdef Q_OS_MAC
-        templatePath = qApp->applicationDirPath() + "/../templates/";
-        qDebug() << templatePath;
-#endif
-#ifdef Q_OS_LINUX
-        templatePath = qApp->applicationDirPath() + "/templates/";
-        if (!QDir(templatePath).exists()) {
-            templatePath = qApp->applicationDirPath() + "/../templates/";
+        QStringList possiblePaths;
+        possiblePaths << qApp->applicationDirPath() + "/templates"
+                      << qApp->applicationDirPath() + "/../templates"
+                      << qApp->applicationDirPath() + "/../../CsoundQt/templates"
+                      << "/usr/share/csoundqt/templates"
+                      << "/usr/local/share/csoundqt/templates";
+
+        foreach (QString path, possiblePaths) {
+            if (QDir(path).exists()) {
+                templatePath = path;
+                break;
+            }
         }
-        if (!QDir(templatePath).exists()) { // for out of tree builds
-            templatePath = qApp->applicationDirPath() + "/../../csoundqt/templates/";
-        }
-        if (!QDir(templatePath).exists()) { // for out of tree builds
-            templatePath = qApp->applicationDirPath() + "/../../CsoundQt/templates/";
-        }
-        if (!QDir(templatePath).exists()) {
-            templatePath = "/usr/share/csoundqt/templates/";
-        }
-#endif
-#ifdef Q_OS_SOLARIS
-        templatePath = qApp->applicationDirPath() + "/templates/";
-        if (!QDir(templatePath).exists()) {
-            templatePath = "/usr/share/qutecsound/templates/";
-        }
-        if (!QDir(templatePath).exists()) {
-            templatePath = qApp->applicationDirPath() + "/../src/templates/";
-        }
-#endif
     }
+    if (templatePath.isEmpty() || !QDir(templatePath).exists()) {
+        qDebug() << "TemplatePath: not found!";
+    } else {
+        qDebug() << "TemplatePath: " << templatePath;
+    }
+
     QStringList filters;
     filters << "*.csd"<<"*.html";
     QStringList templateFiles = QDir(templatePath).entryList(filters,QDir::Files);


### PR DESCRIPTION
The same list of paths is now being tried for all operating systems.

I have omitted the following paths because they appear to be outdated:
```
/usr/share/qutecsound/templates/
qApp->applicationDirPath() + "/../../csoundqt/templates/
qApp->applicationDirPath() + "/../src/templates/
```

(A similar change is needed for `examplePath` as well.)