### PR TITLE
Respect DEFAULT_HTML_DIR constant

### DIFF
--- a/src/csoundqt.cpp
+++ b/src/csoundqt.cpp
@@ -5496,11 +5496,7 @@ void CsoundQt::readSettings()
     m_options->sampleFormat = settings.value("sampleFormat", 0).toInt();
     settings.endGroup();
     settings.beginGroup("Environment");
-#ifdef Q_OS_MAC
     m_options->csdocdir = settings.value("csdocdir", DEFAULT_HTML_DIR).toString();
-#else
-    m_options->csdocdir = settings.value("csdocdir", "").toString();
-#endif
     m_options->opcode7dir64 = settings.value("opcode7dir64","").toString();
     m_options->opcode7dir64Active = settings.value("opcode7dir64Active",false).toBool();
     m_options->sadir = settings.value("sadir","").toString();

--- a/src/types.h
+++ b/src/types.h
@@ -98,7 +98,7 @@
 #define DEFAULT_LOG_FILE ""
 #endif
 #ifdef Q_OS_OPENBSD
-#define DEFAULT_HTML_DIR "/usr/local/share/doc/csound-doc/html"
+#define DEFAULT_HTML_DIR "/usr/local/share/doc/csound/html"
 #define DEFAULT_TERM_EXECUTABLE "xterm"
 #define DEFAULT_BROWSER_EXECUTABLE "firefox"
 #define DEFAULT_WAVEEDITOR_EXECUTABLE "audacity"


### PR DESCRIPTION
Or is there a reason why `DEFAULT_HTML_DIR` is only respected on MACOS? I see none.

(Also fixes the `DEFAULT_HTML_DIR` value for OpenBSD)