### PR TITLE
Remove DEFAULT_HTML_DIR constant

### DIFF
--- a/src/csoundqt.cpp
+++ b/src/csoundqt.cpp
@@ -378,24 +378,27 @@ CsoundQt::CsoundQt(QStringList fileNames)
 
     // try to find directory for manual, if not set
     QString docDir = QString(); //m_options->csdocdir;
-    QString index = docDir + QString("/index.html");
-    QStringList possibleDirectories;
-#ifdef Q_OS_LINUX
-    possibleDirectories  << "/usr/share/doc/csound-manual/html/"
-                         << "/usr/share/doc/csound-doc/html/"
-                         << QCoreApplication::applicationDirPath() + "/../share/doc/csound-manual/html/"   // for transportable apps like AppImage and perhas others
-                         << QCoreApplication::applicationDirPath() + "/../share/doc/csound-doc/html/"   ;
-#endif
-#ifdef Q_OS_WIN
+    if (m_options->csdocdir.isEmpty() ||
+            !QFile::exists(m_options->csdocdir+"/index.html") ) {
+        QStringList possibleDirectories;
+#if defined(Q_OS_WIN)
         QString programFilesPath = QDir::fromNativeSeparators(qgetenv("PROGRAMFILES"));
         QString programFilesPathx86 = QDir::fromNativeSeparators(qgetenv("PROGRAMFILES(X86)"));
-        possibleDirectories << initialDir +"/doc/manual/" << programFilesPath + "/Csound6/doc/manual/" << programFilesPathx86 + "/Csound6/doc/manual/" <<  programFilesPath + "/Csound6_x64/doc/manual/" <<  programFilesPath + "/csound/doc/manual/";
+        possibleDirectories << initialDir +"/doc/manual"
+                            << programFilesPath + "/Csound6/doc/manual"
+                            << programFilesPathx86 + "/Csound6/doc/manual"
+                            << programFilesPath + "/Csound6_x64/doc/manual"
+                            << programFilesPath + "/csound/doc/manual";
+#elif defined(Q_OS_MACOS)
+        possibleDirectories << initialDir + QString("/../Frameworks/CsoundLib64.framework/Resources/Manual")
+                            << "/Library/Frameworks/CsoundLib64.framework/Resources/Manual";
+#else
+        possibleDirectories << "/usr/share/doc/csound-manual/html"
+                            << "/usr/share/doc/csound-doc/html"
+                            << "/usr/local/share/doc/csound/html"
+                            << QCoreApplication::applicationDirPath() + "/../share/doc/csound-manual/html"   // for transportable apps like AppImage and perhas others
+                            << QCoreApplication::applicationDirPath() + "/../share/doc/csound-doc/html";
 #endif
-#ifdef Q_OS_MACOS
-     possibleDirectories <<  initialDir + QString("/../Frameworks/CsoundLib64.framework/Resources/Manual/") <<  "/Library/Frameworks/CsoundLib64.framework/Resources/Manual/";
-#endif
-     if (m_options->csdocdir.isEmpty() ||
-            !QFile::exists(m_options->csdocdir+"/index.html") ) {
         foreach (QString dir, possibleDirectories) {
             qDebug() << "Looking manual in: " << dir;
             if (QFile::exists(dir+"/index.html")) {
@@ -5496,11 +5499,7 @@ void CsoundQt::readSettings()
     m_options->sampleFormat = settings.value("sampleFormat", 0).toInt();
     settings.endGroup();
     settings.beginGroup("Environment");
-#ifdef Q_OS_MAC
-    m_options->csdocdir = settings.value("csdocdir", DEFAULT_HTML_DIR).toString();
-#else
     m_options->csdocdir = settings.value("csdocdir", "").toString();
-#endif
     m_options->opcode7dir64 = settings.value("opcode7dir64","").toString();
     m_options->opcode7dir64Active = settings.value("opcode7dir64Active",false).toBool();
     m_options->sadir = settings.value("sadir","").toString();

--- a/src/types.h
+++ b/src/types.h
@@ -44,7 +44,6 @@
 #define CSQT_MAX_MIDI_QUEUE 128
 
 #ifdef Q_OS_LINUX
-#define DEFAULT_HTML_DIR "/usr/share/doc/csound-doc/html"
 #define DEFAULT_TERM_EXECUTABLE "/usr/bin/xterm"
 #define DEFAULT_BROWSER_EXECUTABLE "/usr/bin/firefox"
 #define DEFAULT_WAVEEDITOR_EXECUTABLE "/usr/bin/audacity"
@@ -52,10 +51,8 @@
 #define DEFAULT_PDFVIEWER_EXECUTABLE "/usr/bin/evince"
 #define DEFAULT_DOT_EXECUTABLE "dot"
 #define DEFAULT_LOG_FILE ""
-#define DEFAULT_SCRIPT_DIR "/usr/share/csoundqt/Scripts"
 #endif
 #ifdef Q_OS_SOLARIS
-#define DEFAULT_HTML_DIR "/usr/local/share/doc/csound/html"
 #define DEFAULT_TERM_EXECUTABLE "/usr/openwin/bin/xterm"
 #define DEFAULT_BROWSER_EXECUTABLE "/usr/bin/firefox"
 #define DEFAULT_WAVEEDITOR_EXECUTABLE "/usr/local/bin/audacity"
@@ -63,10 +60,8 @@
 #define DEFAULT_PDFVIEWER_EXECUTABLE "/usr/bin/evince"
 #define DEFAULT_DOT_EXECUTABLE "dot"
 #define DEFAULT_LOG_FILE ""
-#define DEFAULT_SCRIPT_DIR "../../csoundqt/src/Scripts"
 #endif
 #ifdef Q_OS_MAC
-#define DEFAULT_HTML_DIR "/Library/Frameworks/CsoundLib64.framework/Resources/Manual"
 #define DEFAULT_TERM_EXECUTABLE "/Applications/Utilities/Terminal.app"
 #define DEFAULT_BROWSER_EXECUTABLE "/Applications/Safari.app"  // Safary is installed by default so let's use that
 #define DEFAULT_WAVEEDITOR_EXECUTABLE "/Applications/Audacity.app"
@@ -74,10 +69,8 @@
 #define DEFAULT_PDFVIEWER_EXECUTABLE "/Applications/Preview.app"
 #define DEFAULT_DOT_EXECUTABLE "/usr/local/bin/dot"
 #define DEFAULT_LOG_FILE ""
-#define DEFAULT_SCRIPT_DIR qApp->applicationDirPath() + "/../Resources/Scripts"
 #endif
 #ifdef Q_OS_WIN32
-#define DEFAULT_HTML_DIR "C:/Program Files/Csound/doc/manual"
 #define DEFAULT_TERM_EXECUTABLE "cmd.exe"
 #define DEFAULT_BROWSER_EXECUTABLE ""
 #define DEFAULT_WAVEEDITOR_EXECUTABLE ""
@@ -85,10 +78,8 @@
 #define DEFAULT_PDFVIEWER_EXECUTABLE ""
 #define DEFAULT_DOT_EXECUTABLE ""
 #define DEFAULT_LOG_FILE ""
-#define DEFAULT_SCRIPT_DIR qApp->applicationDirPath() + "/Scripts"
 #endif
 #ifdef Q_OS_HAIKU
-#define DEFAULT_HTML_DIR "/boot/common/share/doc/csound-doc/html"
 #define DEFAULT_TERM_EXECUTABLE "Terminal"
 #define DEFAULT_BROWSER_EXECUTABLE "/boot/apps/WebPositive/WebPositive"
 #define DEFAULT_WAVEEDITOR_EXECUTABLE ""
@@ -98,7 +89,6 @@
 #define DEFAULT_LOG_FILE ""
 #endif
 #ifdef Q_OS_OPENBSD
-#define DEFAULT_HTML_DIR "/usr/local/share/doc/csound-doc/html"
 #define DEFAULT_TERM_EXECUTABLE "xterm"
 #define DEFAULT_BROWSER_EXECUTABLE "firefox"
 #define DEFAULT_WAVEEDITOR_EXECUTABLE "audacity"
@@ -106,7 +96,6 @@
 #define DEFAULT_PDFVIEWER_EXECUTABLE ""
 #define DEFAULT_DOT_EXECUTABLE "dot"
 #define DEFAULT_LOG_FILE ""
-#define DEFAULT_SCRIPT_DIR "/usr/local/share/csoundqt/Scripts"
 #endif
 
 #define CSQT_DEFAULT_TEMPLATE "<CsoundSynthesizer>\n<CsOptions>\n-odac\n</CsOptions>\n<CsInstruments>\n\nsr = 44100\nksmps = 64\nnchnls = 2\n0dbfs = 1\n\n\n</CsInstruments>\n<CsScore>\n\n</CsScore>\n</CsoundSynthesizer>"


### PR DESCRIPTION
This removes the constant completely. There should be no change in behavior except for MACOS where the constant was taken into account before. I've successfully tested it on OpenBSD.

The following changes have been made:
- moved the `possibleDirectories`-code inside `if (m_options->csdocdir.isEmpty() ..`
- removed trailing slashes from the paths
- added a path used on OpenBSD               
- removed the (unused) `DEFAULT_SCRIPT_DIR` constant