### PR TITLE
Fix check for csound library on *BSD

### DIFF
--- a/qcs-unix.pro
+++ b/qcs-unix.pro
@@ -10,9 +10,9 @@ DEFAULT_CSOUND_API_INCLUDE_DIRS += /usr/local/include/csound \
 DEFAULT_CSOUND_INTERFACES_INCLUDE_DIRS += $${DEFAULT_CSOUND_API_INCLUDE_DIRS}
 DEFAULT_CSOUND_LIBRARY_DIRS += /usr/local/lib \
         /usr/lib
-build32:DEFAULT_CSOUND_LIBS = libcsound.so \
+build32:DEFAULT_CSOUND_LIBS = libcsound.so* \
 	libcsound.a
-build64:DEFAULT_CSOUND_LIBS = libcsound64.so \
+build64:DEFAULT_CSOUND_LIBS = libcsound64.so* \
         libcsound64.a
 
 DEFAULT_LIBSNDFILE_LIBRARY_DIRS = /usr/local/lib \


### PR DESCRIPTION
On BSD systems, library filenames have version numbers appended.
The csound library is called `libcsound64.so.X.X`.

For this reason, the check for `libcsound64.so` fails and the following error is printed when running qmake:

`Project ERROR: A valid Csound library directory was not found.`

Using a wildcard works because the `exists()` function supports this.