### PR TITLE
Call refreshModules() after the environment has been initialized

### DIFF
--- a/src/configlists.cpp
+++ b/src/configlists.cpp
@@ -58,9 +58,6 @@ ConfigLists::ConfigLists()
 					<< "schar"<< "float"<< "long";
 	fileFormatNames << "24 Bit" << "16 Bit (short)" << "unsigned 8-bit"
 					<< "signed 8-bit" << "32 bit float"<< "long (32-bit)";
-#ifndef Q_OS_MACOS
-    refreshModules(); // this is too early for signed MacOS bundle. Call it later fro, CsounQt constructor
-#endif
     languages << "English" << "Spanish" << "German" << "French" << "Portuguese"
               << "Italian"  << "Turkish"  << "Finnish" << "Russian" << "Korean"
               << "Persian";

--- a/src/csoundqt.cpp
+++ b/src/csoundqt.cpp
@@ -511,9 +511,7 @@ CsoundQt::CsoundQt(QStringList fileNames)
     // is it necessary here? -  probably called from applySettings already
     // setColors(m_options->themeMode.isEmpty() ? "auto" : m_options->themeMode);
 
-#ifdef Q_OS_MACOS
-    m_configlists.refreshModules(); // must happen after UI is created
-#endif
+    m_configlists.refreshModules(); // must happen after setupEnvironment() has been called 
 
 /*
 #ifdef Q_OS_LINUX


### PR DESCRIPTION
On OpenBSD, audio output works only after the settings dialog has been opened and closed again.

On startup, the following line is printed:
`[D][unknown:0 unknown] void ConfigLists::refreshModules() QList("null")`

The list is empty, because `refreshModules()` is called before `setupEnvironment()`.

With this pull request applied, this is what's printed on startup (and audio output works from the beginning): 
`[D][unknown:0 unknown] void ConfigLists::refreshModules() QList("pulse", "pa_bl", "pa_cb", "null")`

I wonder why this is not a problem on Linux and Windows ..
