### PR TITLE
Metainfo: Correct screenshot tags

### DIFF
--- a/flatpak/io.github.CsoundQt.CsoundQt.metainfo.xml
+++ b/flatpak/io.github.CsoundQt.CsoundQt.metainfo.xml
@@ -52,8 +52,11 @@
   <screenshots>
     <screenshot type="default">
       <image>https://github.com/CsoundQt/CsoundQt/blob/csoundqt7/doc/images/screenshot-linux-spectrumanalyzer.jpg</image>
+      <caption>CsoundQt with the spectrum analyzer being shown</caption>
+    </screenshot>
+    <screenshot>
       <image>https://github.com/CsoundQt/CsoundQt/blob/csoundqt7/doc/images/screenshot1-linux.jpg</image>
-      <image>https://github.com/CsoundQt/CsoundQt/blob/csoundqt7/doc/images/screenshot3-macos.jpg</image>
+      <caption>A screenshot of CsoundQt on Linux</caption>
     </screenshot>
   </screenshots>
 


### PR DESCRIPTION
The screenshot tag bundled several images, which caused the latest build to fail
Additionally, i added captions, and only left linux screenshots, since the standard and Flathub are only for that OS.

Once corrected, this PR can have updated commit and a new build: https://github.com/flathub/io.github.CsoundQt.CsoundQt/pull/2#issuecomment-5172491159